### PR TITLE
DEV-411 [FIX] Ensures that long text in the data list wraps correctly and that rows in edit mode maintain consistent width.

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -16,6 +16,11 @@ fl-list-repeater .list-repeater-load-error {
 
 fl-list-repeater-row {
   position: relative;
+  word-break: break-word;
+  display: block;
+  white-space: normal;
+  overflow-wrap: break-word;
+  width: fit-content;
 }
 
 .mode-interact fl-list-repeater-row[data-view] {
@@ -30,6 +35,7 @@ fl-list-repeater-row {
   background-color: rgba(126, 126, 126, 0.2);
   pointer-events: none;
   opacity: 0.5;
+  width: 100%;
 }
 
 .mode-interact [draggable="true"] fl-list-repeater-row.disabled [draggable="true"],


### PR DESCRIPTION
### Product areas affected

Fliplet Widget List Repeater

### What does this PR do?

Ensures that long text in the data list wraps correctly and that rows in edit mode maintain consistent width.

### JIRA ticket

[DEV-411](https://weboo.atlassian.net/browse/DEV-411)

[DEV-411]: https://weboo.atlassian.net/browse/DEV-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text wrapping and layout for list repeater rows to better handle long words and dynamic content sizing.
  * Disabled list repeater rows now consistently occupy the full available width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->