### PR TITLE
Fix/DEV-250: Ensures all deleted entries are cleared from localStorage once the screen has updated.

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -562,7 +562,11 @@
 
       if (this.rows?.length) {
         const deletedEntriesKey = `deleted-entries-${this.rows[0].dataSourceId}`;
-        localStorage.removeItem(deletedEntriesKey);
+        try {
+          localStorage.removeItem(deletedEntriesKey);
+        } catch (error) {
+          console.warn('Failed to remove localStorage key:', deletedEntriesKey, error);
+        }
       }
 
       this.render();


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Data LIst

### What does this PR do?

Ensures all deleted entries are cleared from localStorage once the screen has updated.

### JIRA tickets

[DEV-250](https://weboo.atlassian.net/browse/DEV-250)

[DEV-250]: https://weboo.atlassian.net/browse/DEV-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured event listeners remain active after row updates.
  * Prevented duplicate data subscriptions by unsubscribing before resubscribing.
  * Improved deletion handling for list items, ensuring accurate updates and removals.
  * Cleaned up outdated deleted entry data from storage after updates.
  * Removed unnecessary delayed no-data message display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->