### PR TITLE
DEV-578 [FIX] Ensures 'Text contains' and 'Text does not contain'  logic are  applicable in Data list component.

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -605,10 +605,10 @@
             query[filter.field] = { $ne: value };
             break;
           case 'contains':
-            query[filter.field] = { $iLike: `%${value}%` };
+            query[filter.field] = { $iLike: value };
             break;
           case 'notcontain':
-            query[filter.field] = { $not: { $iLike: `%${value}%` } };
+            query[filter.field] = { $not: { $iLike: value } };
             break;
           default: // equals
             query[filter.field] = value;


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Data LIst

### What does this PR do?

Ensures 'Text contains' and 'Text does not contain'  logic are  applicable in Data list component.

### JIRA tickets

[DEV-578](https://weboo.atlassian.net/browse/DEV-578)


[DEV-578]: https://weboo.atlassian.net/browse/DEV-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated filter behaviour for 'contains' and 'notcontain' options, changing matching from partial (substring) to exact value matches in queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->