### PR TITLE
Fix/DEV-251: Ensures that the default or configured message is displayed when no data is found in the data list.

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -440,7 +440,7 @@
       if (this.subscription) {
         this.subscription.unsubscribe();
       }
-      
+
       const events = ['insert', 'update', 'delete'];
 
       this.subscription = this.connection.subscribe(
@@ -564,7 +564,7 @@
         deleted: []
       };
 
-     if (this.rows?.length) {
+      if (this.rows?.length) {
         const deletedEntriesKey = `deleted-entries-${this.rows[0].dataSourceId}`;
         try {
           localStorage.removeItem(deletedEntriesKey);
@@ -572,7 +572,7 @@
           console.warn('Failed to remove localStorage key:', deletedEntriesKey, error);
         }
       }
-      
+
       this.render();
     }
 


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Conditional Container

### What does this PR do?

Ensures that the default or configured message is displayed when no data is found in the data list.

### JIRA tickets

[DEV-251](https://weboo.atlassian.net/browse/DEV-251)

[DEV-251]: https://weboo.atlassian.net/browse/DEV-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the no-data message to display only when appropriate, ensuring it appears only if there are no rows or all rows are empty and not in interact mode.
  * Prevented duplicate event listeners from being attached during row updates.
  * Refined row deletion logic for more accurate updates to the displayed list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->