### PR TITLE
Fix/DEV-411: Ensures Data List takes its parent widget width.

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -1,3 +1,7 @@
+[data-widget-package="com.fliplet.list-repeater"] {
+  width: 100%;
+}
+
 fl-list-repeater {
   display: flex;
 }
@@ -20,7 +24,6 @@ fl-list-repeater-row {
   display: block;
   white-space: normal;
   overflow-wrap: break-word;
-  width: fit-content;
 }
 
 .mode-interact fl-list-repeater-row[data-view] {

--- a/css/build.css
+++ b/css/build.css
@@ -16,6 +16,11 @@ fl-list-repeater .list-repeater-load-error {
 
 fl-list-repeater-row {
   position: relative;
+  word-break: break-word;
+  display: block;
+  white-space: normal;
+  overflow-wrap: break-word;
+  width: fit-content;
 }
 
 .mode-interact fl-list-repeater-row[data-view] {
@@ -30,6 +35,7 @@ fl-list-repeater-row {
   background-color: rgba(126, 126, 126, 0.2);
   pointer-events: none;
   opacity: 0.5;
+  width: 100%;
 }
 
 .mode-interact [draggable="true"] fl-list-repeater-row.disabled [draggable="true"],


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Data LIst

### What does this PR do?

Ensures Data List takes its parent widget width.

### JIRA tickets

[DEV-411](https://weboo.atlassian.net/browse/DEV-411)

[DEV-411]: https://weboo.atlassian.net/browse/DEV-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Ensured elements with the specified widget attribute now span 100% width.
  * Removed fixed width from list repeater rows for improved layout flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->