### PR TITLE
fix(DEV-1068): add clickAction.page reference for clone remapping

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -7,7 +7,7 @@
   "tags": ["type:component", "category:layout", "beta:true"],
   "provider_only": false,
   "html_tag": "div",
-  "references": ["content:richContent"],
+  "references": ["content:richContent", "clickAction.page:page"],
   "settings": {
     "interfaceWidgetPackage": "com.fliplet.helper-configuration",
     "asyncRendering": true,


### PR DESCRIPTION
## Summary
- Add `clickAction.page:page` to top-level `references` array in widget.json

The list repeater stores a page reference via the link provider at `clickAction.page` but never declared it, causing cloned apps to navigate to the source app's page.

## Test plan
- [ ] Clone an app with a Data List widget that has a click action pointing to a page
- [ ] Verify the cloned widget's `clickAction.page` points to the new cloned page

🤖 Generated with [Claude Code](https://claude.com/claude-code)